### PR TITLE
Changed program to handle ValueError exceptions for choosing menu option instead of Exception exceptions

### DIFF
--- a/calc_app.py
+++ b/calc_app.py
@@ -148,7 +148,7 @@ while menu_options != 3 :
 
 
         else :
-            raise Exception("Please select a valid menu option!")
+            raise ValueError
    
-    except Exception:
+    except ValueError:
         print("Please select a valid menu option!")


### PR DESCRIPTION
As per issue-2, the Program was handling all exceptions under the general "raise Exception" and "except Exception" handles. This was general and not considered to be the "Pythonic" way. Changed the exception handling to "raise ValueError" and "except ValueError" handles to print the correct ValueError exception message for when a user chooses an invalid menu option.